### PR TITLE
Master cmake clang build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,9 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR
   else()
     set(CODY_REVISION, "unknown")
   endif ()
-
+  set(LIBCODY_STANDALONE YES)
+else()
+  set(LIBCODY_STANDALONE NO)
 endif()
 
 # We are using C++11
@@ -71,7 +73,9 @@ option(CODY_CHECKING "Enable checking" ON)
 # Address github issue #10
 option(CODY_WITHEXCEPTIONS "Enable exceptions" OFF)
 
-include(CTest)
+if (LIBCODY_STANDALONE)
+  include(CTest)
+endif()
 
 include(libcody-config-ix)
 
@@ -100,14 +104,14 @@ set(LIBCODY_SOURCES
   packet.cc
   server.cc)
 
-if(add_llvm_component_library)
-  add_llvm_component_library(LLVMcody ${LIBCODY_SOURCES})
-else()
+if(LIBCODY_STANDALONE)
   add_library(cody STATIC ${LIBCODY_SOURCES})
+else()
+  message(STATUS "Configured for in-tree build of libcody as LLVMcody")
+  add_llvm_component_library(LLVMcody ${LIBCODY_SOURCES})
 endif()
 
-if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR
-   OR LIBCODY_STANDALONE_BUILD)
+if (LIBCODY_STANDALONE)
 
   set_target_properties(cody PROPERTIES PUBLIC_HEADER "cody-conf.h;cody.hh")
   install(TARGETS cody 

--- a/cody.hh
+++ b/cody.hh
@@ -5,7 +5,12 @@
 #ifndef CODY_HH
 #define CODY_HH 1
 
-#include "cody-conf.h"
+#if defined(__has_include) && __has_include("cody-conf.h")
+# include "cody-conf.h"
+#else
+# include "cody-conf.h"
+#endif
+
 // C++
 #include <memory>
 #include <string>


### PR DESCRIPTION
two patchlets for clang support.

1/ avoid the need to install the empty cody-config.hh when the compiler supports __has_include (which is most likely all compilers that can build the code).  This avoids the need to generate the empty header in the cmake configuration (we can revisit if the header becomes non-empty).

2/ Although the library was building in the LLVM tree for "make [all]", the dependencies were not correct when doing "make clang" with the library as a required sub-dependency of a clang constituent library.  Fixed by making the build explicit as 'stand alone' and otherwise presuming it to be an LLVM-based configuration (which is the intent of the cmake implementation).