### PR TITLE
libcody : Fixes for older 32b hosts.

### DIFF
--- a/netclient.cc
+++ b/netclient.cc
@@ -15,6 +15,10 @@
 #include <arpa/inet.h>
 #include <sys/un.h>
 
+#ifndef AI_NUMERICSERV
+#define AI_NUMERICSERV 0
+#endif
+
 // Client-side networking helpers
 
 namespace Cody {

--- a/netserver.cc
+++ b/netserver.cc
@@ -14,6 +14,10 @@
 #include <arpa/inet.h>
 #include <sys/un.h>
 
+#ifndef AI_NUMERICSERV
+#define AI_NUMERICSERV 0
+#endif
+
 // Server-side networking helpers
 
 namespace Cody {

--- a/resolver.cc
+++ b/resolver.cc
@@ -10,7 +10,9 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#if defined (__unix__) || defined (__MACH__)
+#if defined (__unix__) || (defined (__Apple__) && \
+   (defined (__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && \
+    __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 101000))
 // Autoconf test?
 #define HAVE_FSTATAT 1
 #else


### PR DESCRIPTION
Presumably, if AI_NUMERICSERV is not available, there's really not much
of a fall-back so we might as well just set that to 0.

fstatat is available on macOS from 10.10+, we build GCC back to at least
10.5.
