### PR TITLE
Fix libcody not working with C++20 project

### DIFF
--- a/buffer.cc
+++ b/buffer.cc
@@ -383,5 +383,10 @@ void MessageBuffer::LexedLine (std::string &str)
       str.append (&buffer[pos], end - pos);
     }
 }
+
+void MessageBuffer::Space ()
+{
+  Append (Detail::S2C(u8" "));
+}
 } // Detail
 } // Cody

--- a/cody.hh
+++ b/cody.hh
@@ -104,10 +104,7 @@ public:
 
   ///
   /// Add whitespace word separator.  Multiple adjacent whitespace is fine.
-  void Space ()
-  {
-    Append (Detail::S2C(" "));
-  }
+  void Space ();
 
 public:
   /// Add a word as with Append, but prefixing whitespace to make a

--- a/cody.hh
+++ b/cody.hh
@@ -106,7 +106,7 @@ public:
   /// Add whitespace word separator.  Multiple adjacent whitespace is fine.
   void Space ()
   {
-    Append (Detail::S2C(u8" "));
+    Append (Detail::S2C(" "));
   }
 
 public:


### PR DESCRIPTION
Since C++20, the type of `u8"..."` is `const char8_t[N]`, not `const char[N]`.