### PR TITLE
Add space to error message.

### DIFF
--- a/client.cc
+++ b/client.cc
@@ -97,7 +97,7 @@ int Client::CommunicateWithServer ()
 
 static Packet CommunicationError (int err)
 {
-  std::string e {u8"communication error:"};
+  std::string e {u8"communication error: "};
   e.append (strerror (err));
 
   return Packet (Client::PC_ERROR, std::move (e));


### PR DESCRIPTION
Hi,

Currently the error is sticked to previous phrase.
Like
```
main.cpp:1:1: fatal error: unknown Compiled Module Interface: communication error:Unknown error -1
will be
main.cpp:1:1: fatal error: unknown Compiled Module Interface: communication error: Unknown error -1
```

Should I also send patch to gcc or libcody is eventually updated from here?

---

Also I've naively fixed an ICE in module.cc (`void module_state::set_filename (const Cody::Packet &packet)`):
```
-      error_at (loc, "unknown Compiled Module Interface: %s",
		packet.GetString ().c_str ());
+      fatal_error (loc, "unknown Compiled Module Interface: %s",
		packet.GetString ().c_str ());
```

If we do not fail here, tons of ICEs come later.
There can be communication error, so we do not get same number of packets sent about querying modules.
The following function 
```
static void
name_pending_imports (cpp_reader *reader)
```
iterates over responses and does not check for `r_iter == response.end()`
```
	      module->set_filename (*r_iter);
	      ++r_iter;
```