### PR TITLE
libcody: Avoid a crash in getaddrinfo() on some BSD/BSD-derived versi…

### DIFF
--- a/netclient.cc
+++ b/netclient.cc
@@ -74,6 +74,13 @@ int OpenInet6 (char const **e, char const *name, int port)
   int fd = -1;
   char const *errstr = nullptr;
 
+  if (!name || name[0] == 0)
+    {
+      errstr = "missing server name";
+      errno = EINVAL;
+      goto fail;
+    }
+
   fd = socket (AF_INET6, SOCK_STREAM, 0);
   if (fd < 0)
     {
@@ -92,7 +99,7 @@ int OpenInet6 (char const **e, char const *name, int port)
     }
 
   addrinfo hints;
-  hints.ai_flags = AI_NUMERICSERV;
+  hints.ai_flags = 0;
   hints.ai_family = AF_INET6;
   hints.ai_socktype = SOCK_STREAM;
   hints.ai_protocol = 0;
@@ -101,9 +108,7 @@ int OpenInet6 (char const **e, char const *name, int port)
   hints.ai_canonname = nullptr;
   hints.ai_next = nullptr;
 
-  /* getaddrinfo requires a port number, but is quite happy to accept
-     invalid ones.  So don't rely on it.  */
-  if (int err = getaddrinfo (name, "0", &hints, &addrs))
+  if (int err = getaddrinfo (name, nullptr, &hints, &addrs))
     {
       errstr = gai_strerror (err);
       // What's the best errno to set?


### PR DESCRIPTION
…ons.

In some cases, on some older BSD versions (and macOS versions based on
that code) getaddrinfo() crashes when given ai_flags = AI_NUMERICSERV
together with either a nullptr or the literal string "0" for the
servname parameter.

In the case of OpenInet6() it seems that there is no useful case when
we could have an empty name (and we ignore the port number passed when
calling getaddrinfo).

The change here diagnoses a missing server name early, and then calls the
getaddrinfo() with ai_flags = 0 and a nullptr for servname.

We do check the validity of the port number in the next section of the
code that carries out the connect.

When applied to the GCC implementation of P1184, this fixes the remaining
fails on the affected macOS versions.